### PR TITLE
Ort 1.16 - v2.0.0-rc.12 migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,7 +18,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
 ]
@@ -108,12 +102,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -133,9 +133,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -268,6 +268,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,41 +327,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "der"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -392,16 +380,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
-name = "filetime"
-version = "0.2.26"
+name = "fastrand"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.60.2",
-]
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -410,34 +392,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
-name = "flate2"
-version = "1.1.2"
+name = "foreign-types"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "crc32fast",
- "miniz_oxide",
+ "foreign-types-shared",
 ]
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
+name = "foreign-types-shared"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "getrandom"
@@ -448,7 +415,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasi",
 ]
 
 [[package]]
@@ -456,16 +423,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "half"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
-dependencies = [
- "cfg-if",
- "crunchy",
-]
 
 [[package]]
 name = "hashbrown"
@@ -480,117 +437,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
-name = "icu_collections"
-version = "2.0.0"
+name = "http"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
+ "bytes",
+ "itoa",
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.0.0"
+name = "httparse"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
-
-[[package]]
-name = "icu_properties"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "potential_utf",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
-
-[[package]]
-name = "icu_provider"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "indexmap"
@@ -651,7 +523,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
  "libc",
 ]
 
@@ -672,7 +544,7 @@ dependencies = [
  "clang-sys",
  "clap",
  "hound",
- "ndarray",
+ "ndarray 0.15.6",
  "ort",
  "regex",
  "rodio",
@@ -713,33 +585,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
-dependencies = [
- "bitflags 2.9.4",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
-name = "litemap"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
-
-[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 
 [[package]]
 name = "mach2"
@@ -773,12 +634,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
+name = "native-tls"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
- "adler2",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -795,12 +664,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "ndk"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -938,23 +822,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
-name = "ort"
-version = "1.16.3"
+name = "openssl"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889dca4c98efa21b1ba54ddb2bde44fd4920d910f492b618351f839d8428d79d"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "flate2",
- "half",
- "lazy_static",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
  "libc",
- "ndarray",
- "tar",
- "thiserror",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray 0.17.2",
+ "ort-sys",
+ "smallvec",
  "tracing",
  "ureq",
- "vswhom",
- "winapi",
- "zip",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -976,12 +916,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "potential_utf"
-version = "0.1.3"
+name = "portable-atomic"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
- "zerovec",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1024,15 +970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags 2.9.4",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,20 +999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.16",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rodio"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,26 +1023,11 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.1",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1129,17 +1037,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -1164,13 +1061,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
- "serde_derive",
 ]
 
 [[package]]
@@ -1219,22 +1147,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
+name = "socks"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphonia"
@@ -1393,25 +1320,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
+name = "tempfile"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1432,16 +1350,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -1496,19 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1527,43 +1423,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
+ "der",
  "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "url"
-version = "2.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
-dependencies = [
- "form_urlencoded",
- "idna",
+ "native-tls",
  "percent-encoding",
- "serde",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
 ]
 
 [[package]]
-name = "utf8_iter"
-version = "1.0.4"
+name = "ureq-proto"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8parse"
@@ -1572,24 +1465,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "vswhom"
-version = "0.1.0"
+name = "vcpkg"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
-dependencies = [
- "libc",
- "vswhom-sys",
-]
-
-[[package]]
-name = "vswhom-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
-dependencies = [
- "cc",
- "libc",
-]
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "walkdir"
@@ -1600,12 +1479,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1708,19 +1581,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
+name = "webpki-root-certs"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.2",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1798,15 +1662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2029,113 +1884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "writeable"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
-
-[[package]]
-name = "yoke"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clang-sys = { version = "1.8", features = ["runtime"] }
 regex = "1.11.0"
 ndarray = "0.15"
 hound = "3.5"
-ort = { version = "1.16", features = ["download-binaries"] }
+ort = { version = "2.0.0-rc.12", features = ["download-binaries"] }
 clap = { version = "4.5", features = ["derive"] }
 serde_json = "1.0"
 rodio = { version = "0.17", features = ["symphonia-all"] }

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,3 +1,5 @@
+use ort::session::builder::GraphOptimizationLevel;
+
 use crate::kokoro::{load_voice_style, KokoroTTS, TTSConfig};
 use crate::playback::play_wav_file;
 use std::io::{self, Write};
@@ -14,7 +16,7 @@ impl InteractiveTTS {
     pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
         let tts_config =
             TTSConfig::new("models/kokoro/kokoro.onnx", "models/kokoro/tokenizer.json")
-                .with_graph_optimization_level(ort::GraphOptimizationLevel::Disable)
+                .with_graph_optimization_level(GraphOptimizationLevel::Disable)
                 .with_max_tokens_length(512)
                 .with_sample_rate(24000);
 
@@ -96,11 +98,11 @@ pub fn run_interactive_tts_with_options(
     println!("Initializing Interactive TTS with custom options...");
 
     let tts_config = TTSConfig::new("models/kokoro/kokoro.onnx", "models/kokoro/tokenizer.json")
-        .with_graph_optimization_level(ort::GraphOptimizationLevel::Disable)
+        .with_graph_optimization_level(GraphOptimizationLevel::Disable)
         .with_max_tokens_length(512)
         .with_sample_rate(24000);
 
-    let tts = KokoroTTS::with_config(tts_config)?;
+    let mut tts = KokoroTTS::with_config(tts_config)?;
 
     let voice_path = voice_path.unwrap_or("models/kokoro/af.bin");
     let voice_style = load_voice_style(voice_path)?;

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -68,10 +68,10 @@ impl InteractiveTTS {
         self.output_counter += 1;
         let filename = "interactive_tts.wav";
         let audio = self.tts.generate_speech(text, &self.voice_style, 1.0)?;
-        audio.save_to_wav(&filename)?;
+        audio.save_to_wav(filename)?;
         let generation_time = start_time.elapsed();
 
-        play_wav_file(&filename)?;
+        play_wav_file(filename)?;
 
         if std::env::var("DEBUG_TIMING").is_ok() {
             println!(

--- a/src/kokoro/tts.rs
+++ b/src/kokoro/tts.rs
@@ -1,11 +1,13 @@
 use super::voice::VoiceStyle;
 use crate::espeak::EspeakIpaTokenizer;
-use ndarray::{Array1, Array2, CowArray, IxDyn};
-use ort::{Environment, ExecutionProvider, GraphOptimizationLevel, Session, SessionBuilder, Value};
+use ort::ep::ExecutionProviderDispatch;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::session::Session;
+use ort::value::Tensor;
+use ort::{self, inputs};
 use std::error::Error;
 use std::io::Cursor;
 use std::path::Path;
-use std::sync::Arc;
 
 pub struct TTSConfig {
     pub model_path: String,
@@ -13,7 +15,7 @@ pub struct TTSConfig {
     pub max_length: usize,
     pub sample_rate: u32,
     pub graph_level: GraphOptimizationLevel,
-    pub execution_provider: Vec<ExecutionProvider>,
+    pub execution_provider: Vec<ExecutionProviderDispatch>,
 }
 
 impl TTSConfig {
@@ -43,7 +45,7 @@ impl TTSConfig {
         self
     }
 
-    pub fn with_execution_providers(mut self, providers: Vec<ExecutionProvider>) -> Self {
+    pub fn with_execution_providers(mut self, providers: Vec<ExecutionProviderDispatch>) -> Self {
         self.execution_provider = providers;
         self
     }
@@ -117,16 +119,18 @@ impl KokoroTTS {
             execution_provider,
         } = config;
 
-        let env = Arc::new(Environment::builder().with_name("kokoro_tts").build()?);
+        //let env = Arc::new(ort::init().with_name("kokoro_tts"));
+        //let env = Arc::new(Environment::builder().with_name("kokoro_tts").build()?);
 
         let optimization = match graph_level {
             GraphOptimizationLevel::Disable => GraphOptimizationLevel::Disable,
             GraphOptimizationLevel::Level1 => GraphOptimizationLevel::Level1,
             GraphOptimizationLevel::Level2 => GraphOptimizationLevel::Level2,
             GraphOptimizationLevel::Level3 => GraphOptimizationLevel::Level3,
+            GraphOptimizationLevel::All => todo!(),
         };
 
-        let mut builder = SessionBuilder::new(&env)?
+        let mut builder = Session::builder()?
             .with_optimization_level(optimization)?
             .with_parallel_execution(true)?;
 
@@ -134,7 +138,7 @@ impl KokoroTTS {
             builder = builder.with_execution_providers(&execution_provider)?;
         }
 
-        let session = builder.with_model_from_file(&model_path)?;
+        let session = builder.commit_from_file(&model_path)?;
 
         let tokenizer_content = std::fs::read_to_string(&tokenizer_path)?;
         let tokenizer_json: serde_json::Value = serde_json::from_str(&tokenizer_content)?;
@@ -157,7 +161,7 @@ impl KokoroTTS {
     }
 
     pub fn generate_speech_from_phonemes(
-        &self,
+        &mut self,
         phonemes: &str,
         voice_style: &VoiceStyle,
         speed: f32,
@@ -168,7 +172,7 @@ impl KokoroTTS {
     }
 
     pub fn generate_speech(
-        &self,
+        &mut self,
         text: &str,
         voice_style: &VoiceStyle,
         speed: f32,
@@ -179,30 +183,22 @@ impl KokoroTTS {
     }
 
     pub fn generate_from_tokens(
-        &self,
+        &mut self,
         tokens: &[i64],
         voice_style: &VoiceStyle,
         speed: f32,
     ) -> Result<GeneratedAudio, Box<dyn Error>> {
-        let input_ids = Array2::<i64>::from_shape_vec((1, tokens.len()), tokens.to_vec())?;
-        // Use token length to select the appropriate style vector, matching Python implementation
         let style_vector = voice_style.get_style_vector_for_token_length(tokens.len(), 256);
-        let style = Array2::<f32>::from_shape_vec((1, 256), style_vector)?;
-        let speed_array = Array1::<f32>::from_vec(vec![speed]);
 
-        let input_ids_cow: CowArray<i64, IxDyn> = CowArray::from(input_ids.into_dyn());
-        let style_cow: CowArray<f32, IxDyn> = CowArray::from(style.into_dyn());
-        let speed_cow: CowArray<f32, IxDyn> = CowArray::from(speed_array.into_dyn());
-
-        let input_ids_tensor = Value::from_array(self.session.allocator(), &input_ids_cow)?;
-        let style_tensor = Value::from_array(self.session.allocator(), &style_cow)?;
-        let speed_tensor = Value::from_array(self.session.allocator(), &speed_cow)?;
+        let input_ids_tensor = Tensor::from_array(([1, tokens.len()], tokens.to_vec()))?;
+        let style_tensor = Tensor::from_array(([1usize, 256], style_vector))?;
+        let speed_tensor = Tensor::from_array(([1usize], vec![speed]))?;
 
         let outputs = self
             .session
-            .run(vec![input_ids_tensor, style_tensor, speed_tensor])?;
+            .run(inputs![input_ids_tensor, style_tensor, speed_tensor])?;
 
-        if let Ok(output) = outputs[0].try_extract::<f32>() {
+        if let Ok(output) = outputs[0].try_extract_array::<f32>() {
             let view = output.view();
             let samples = view.as_slice().unwrap().to_vec();
             let duration_seconds = samples.len() as f32 / self.sample_rate as f32;
@@ -221,7 +217,7 @@ impl KokoroTTS {
 
     #[allow(dead_code)]
     pub fn speak(
-        &self,
+        &mut self,
         text: &str,
         voice_style: &VoiceStyle,
     ) -> Result<GeneratedAudio, Box<dyn Error>> {

--- a/src/kokoro/tts.rs
+++ b/src/kokoro/tts.rs
@@ -127,7 +127,7 @@ impl KokoroTTS {
             GraphOptimizationLevel::Level1 => GraphOptimizationLevel::Level1,
             GraphOptimizationLevel::Level2 => GraphOptimizationLevel::Level2,
             GraphOptimizationLevel::Level3 => GraphOptimizationLevel::Level3,
-            GraphOptimizationLevel::All => todo!(),
+            GraphOptimizationLevel::All => GraphOptimizationLevel::All,
         };
 
         let mut builder = Session::builder()?

--- a/src/kokoro/tts.rs
+++ b/src/kokoro/tts.rs
@@ -85,7 +85,7 @@ impl GeneratedAudio {
             // Write the actual audio
             for &sample in &self.samples {
                 // Clamp to prevent overflow
-                let clamped = sample.max(-1.0).min(1.0);
+                let clamped = sample.clamp(-1.0, 1.0);
                 let amplitude = (clamped * i16::MAX as f32) as i16;
                 writer.write_sample(amplitude)?;
             }

--- a/src/kokoro/tts.rs
+++ b/src/kokoro/tts.rs
@@ -119,19 +119,8 @@ impl KokoroTTS {
             execution_provider,
         } = config;
 
-        //let env = Arc::new(ort::init().with_name("kokoro_tts"));
-        //let env = Arc::new(Environment::builder().with_name("kokoro_tts").build()?);
-
-        let optimization = match graph_level {
-            GraphOptimizationLevel::Disable => GraphOptimizationLevel::Disable,
-            GraphOptimizationLevel::Level1 => GraphOptimizationLevel::Level1,
-            GraphOptimizationLevel::Level2 => GraphOptimizationLevel::Level2,
-            GraphOptimizationLevel::Level3 => GraphOptimizationLevel::Level3,
-            GraphOptimizationLevel::All => GraphOptimizationLevel::All,
-        };
-
         let mut builder = Session::builder()?
-            .with_optimization_level(optimization)?
+            .with_optimization_level(graph_level)?
             .with_parallel_execution(true)?;
 
         if !execution_provider.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Configure and initialize Kokoro TTS
 //! let config = TTSConfig::new("path/to/model.onnx", "path/to/tokenizer.json");
-//! let tts = KokoroTTS::with_config(config)?;
+//! let mut tts = KokoroTTS::with_config(config)?;
 //!
 //! // Load a voice style
 //! let voice = load_voice_style("path/to/voice.bin")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,3 @@ pub mod kokoro;
 
 // Re-export main types for convenience
 pub use kokoro::{load_voice_style, GeneratedAudio, KokoroTTS, TTSConfig, VoiceStyle};
-
-// Re-export ONNX GraphOptimizationLevel for configuration
-pub use ort::GraphOptimizationLevel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,3 +40,5 @@ pub mod kokoro;
 
 // Re-export main types for convenience
 pub use kokoro::{load_voice_style, GeneratedAudio, KokoroTTS, TTSConfig, VoiceStyle};
+
+pub use ort::session::builder::GraphOptimizationLevel;

--- a/src/test/identity_test.rs
+++ b/src/test/identity_test.rs
@@ -1,24 +1,24 @@
-use ndarray::{Array1, CowArray, IxDyn};
-use ort::{Environment, GraphOptimizationLevel, SessionBuilder, Value};
-use std::sync::Arc;
+use ort::{
+    inputs,
+    session::{builder::GraphOptimizationLevel, Session},
+    value::Tensor,
+};
 
 pub fn run_identity() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize the ONNX Runtime environment
-    let env = Arc::new(Environment::builder().with_name("id").build()?);
+    //let env = Arc::new(Environment::builder().with_name("id").build()?);
 
     // Build the session
-    let session = SessionBuilder::new(&env)?
+    let mut session = Session::builder()?
         .with_optimization_level(GraphOptimizationLevel::Level3)?
-        .with_model_from_file("models/identity_v8.onnx")?;
+        .commit_from_file("models/identity_v8.onnx")?;
 
     // Create input tensor
-    let input = Array1::<f32>::from_vec(vec![2.0]);
-    let input_cow: CowArray<f32, IxDyn> = CowArray::from(input.into_dyn());
-    let input_tensor = Value::from_array(session.allocator(), &input_cow)?;
+    let input_tensor = Tensor::from_array(([1usize], vec![2.0f32]))?; // ? here
 
     // Run inference
-    let outputs = session.run(vec![input_tensor])?;
-    let output = outputs[0].try_extract::<f32>()?;
+    let outputs = session.run(inputs![input_tensor])?;
+    let output = outputs[0].try_extract_array::<f32>()?;
     let output_view = output.view();
     println!("out = {:?}", output_view.as_slice().unwrap());
     Ok(())

--- a/src/test/kokoro_test.rs
+++ b/src/test/kokoro_test.rs
@@ -1,6 +1,6 @@
-use ort::execution_providers::CoreMLExecutionProviderOptions;
 use crate::kokoro::{load_voice_style, KokoroTTS, TTSConfig};
 use crate::playback::play_wav_file;
+use ort::session::builder::GraphOptimizationLevel;
 
 pub fn run_kokoro(no_play: bool) -> Result<(), Box<dyn std::error::Error>> {
     run_kokoro_with_text("Hello world, how are you today?", no_play)
@@ -10,14 +10,12 @@ pub fn run_kokoro_with_text(text: &str, no_play: bool) -> Result<(), Box<dyn std
     println!("Initializing Kokoro TTS...");
 
     let tts_config = TTSConfig::new("models/kokoro/kokoro.onnx", "models/kokoro/tokenizer.json")
-        .with_graph_optimization_level(ort::GraphOptimizationLevel::Disable)
+        .with_graph_optimization_level(GraphOptimizationLevel::Disable)
         .with_max_tokens_length(512)
         .with_sample_rate(24000)
-        .with_execution_providers(vec![
-            ort::ExecutionProvider::CoreML(CoreMLExecutionProviderOptions::default())
-        ]);
+        .with_execution_providers(vec![ort::ep::CoreML::default().into()]);
 
-    let tts = KokoroTTS::with_config(tts_config)?;
+    let mut tts = KokoroTTS::with_config(tts_config)?;
 
     let voice = load_voice_style("models/kokoro/af.bin")?;
 

--- a/src/test/test_direct_phonemes.rs
+++ b/src/test/test_direct_phonemes.rs
@@ -1,3 +1,5 @@
+use ort::session::builder::GraphOptimizationLevel;
+
 use crate::kokoro::{load_voice_style, KokoroTTS, TTSConfig};
 use crate::playback::play_wav_file;
 
@@ -6,11 +8,11 @@ pub fn test_direct_phonemes() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize TTS
     let tts_config = TTSConfig::new("models/kokoro/kokoro.onnx", "models/kokoro/tokenizer.json")
-        .with_graph_optimization_level(ort::GraphOptimizationLevel::Disable)
+        .with_graph_optimization_level(GraphOptimizationLevel::Disable)
         .with_max_tokens_length(512)
         .with_sample_rate(24000);
 
-    let tts = KokoroTTS::with_config(tts_config)?;
+    let mut tts = KokoroTTS::with_config(tts_config)?;
 
     let voice_style = load_voice_style("models/kokoro/af.bin")?;
 

--- a/src/test/test_raw_tokens.rs
+++ b/src/test/test_raw_tokens.rs
@@ -1,4 +1,5 @@
 use crate::kokoro::{load_voice_style, KokoroTTS, TTSConfig};
+use ort::session::builder::GraphOptimizationLevel;
 use std::error::Error;
 
 pub fn test_raw_tokens() -> Result<(), Box<dyn Error>> {
@@ -6,11 +7,11 @@ pub fn test_raw_tokens() -> Result<(), Box<dyn Error>> {
 
     // Initialize TTS
     let tts_config = TTSConfig::new("models/kokoro/kokoro.onnx", "models/kokoro/tokenizer.json")
-        .with_graph_optimization_level(ort::GraphOptimizationLevel::Disable)
+        .with_graph_optimization_level(GraphOptimizationLevel::Disable)
         .with_max_tokens_length(512)
         .with_sample_rate(24000);
 
-    let tts = KokoroTTS::with_config(tts_config)?;
+    let mut tts = KokoroTTS::with_config(tts_config)?;
 
     // Example tokens in the format you provided
     let tokens: Vec<i64> = vec![


### PR DESCRIPTION
Hello.
I've migrated the code to ort 2.0.0-rc.12 since I couldn't run the latest kokoro onnx model on 1.16.
I've ran all the test examples, updated docs and everything seems to work fine.
Thank you in advance.